### PR TITLE
Allow Overseerr to have a URL with no port

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -38,7 +38,7 @@ function setOrigin(apiKey, ip, port, protocol, path, callback) {
     serverPort = port;
     serverProtocol = protocol;
     serverPath = path;
-    if (serverPort.length==0){
+    if (serverPort.length===0){
         origin = `${serverProtocol}://${serverIp}${serverPath}`;
     }
     else {

--- a/js/storage.js
+++ b/js/storage.js
@@ -5,7 +5,7 @@ function pullStoredData(callback) {
     chrome.storage.sync.get(['serverAPIKey', 'serverIp', 'serverPort', 'serverProtocol', 'serverPath', 'userId', 'overseerrVersion'], function(data) {
         serverAPIKey = data.serverAPIKey || '';
         serverIp = data.serverIp || '172.0.0.1';
-        serverPort = data.serverPort || 8001;
+        serverPort = data.serverPort;
         serverProtocol = data.serverProtocol || 'http';
         serverPath = data.serverPath || '/'
         origin = `${serverProtocol}://${serverIp}:${serverPort}${serverPath}`;
@@ -38,7 +38,12 @@ function setOrigin(apiKey, ip, port, protocol, path, callback) {
     serverPort = port;
     serverProtocol = protocol;
     serverPath = path;
-    origin = `${serverProtocol}://${serverIp}:${serverPort}${serverPath}`;
+    if (serverPort.length==0){
+        origin = `${serverProtocol}://${serverIp}${serverPath}`;
+    }
+    else {
+        origin = `${serverProtocol}://${serverIp}:${serverPort}${serverPath}`;
+    }
     if (origin.endsWith('/')) {
         origin = origin.slice(0, origin.length - 1);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Overseerr Assistant",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Browser extension for Overseerr that embeds buttons into IMDb and TMDB web pages to easily request movies and tv shows.",
   "permissions": ["storage"],
   "host_permissions": ["http://*/", "https://*/"],


### PR DESCRIPTION
If you use a subdomain or domain name with Overseerr the Overseerr-Assistant would not work as you need a port specified.

I modified the Overseerr-Assistant to allow you to have a URL with no port