### PR TITLE
Refactor getPlexToken to use localStorage

### DIFF
--- a/js/content-scripts/plex.js
+++ b/js/content-scripts/plex.js
@@ -19,17 +19,7 @@ function arrangeMargins() {
 }
 
 function getPlexToken() {
-    let imageElements = $('img').filter(function() {
-        return $(this).attr('src').includes('X-Plex-Token');
-    });
-    if (imageElements.length > 0) {
-        let pattern = /.X-Plex-Token=(\w+)/;
-        let matches = imageElements.attr('src').match(pattern);
-        if (matches !== null && matches.length > 1) {
-            return matches[1];
-        }
-    }
-    return null;
+    return localStorage.getItem('myPlexAccessToken');
 }
 
 function getMediaKey() {


### PR DESCRIPTION
Refactor getPlexToken function to retrieve token from localStorage instead of filtering image elements.

The `(w+)` regex no longer works because newer Plex tokens may contain the `-` and `_` characters.